### PR TITLE
Erweiterung AMELAG-Datenschema

### DIFF
--- a/Metadaten/schemas/amelag_aggregierte_kurve.csvs
+++ b/Metadaten/schemas/amelag_aggregierte_kurve.csvs
@@ -1,5 +1,5 @@
 version 1.1
-@totalColumns 7
+@totalColumns 9
 @separator TAB
 datum: xDate
 n: positiveInteger or is("NA")
@@ -8,3 +8,5 @@ viruslast:  regex("[0-9]+|([0-9]+\.([0-9]+))") or is("NA")
 loess_vorhersage:  regex("[0-9]+|([0-9]+\.([0-9]+))")
 loess_obere_schranke:  regex("[0-9]+|([0-9]+\.([0-9]+))")
 loess_untere_schranke:  regex("[0-9]+|([0-9]+\.([0-9]+))")
+normalisierung: any("ja", "nein", "NA")
+typ: any("Influenza-A", "Influenza-B", "Influenza-Gesamt", "SARS-CoV-2")

--- a/Metadaten/schemas/amelag_einzelstandorte.csvs
+++ b/Metadaten/schemas/amelag_einzelstandorte.csvs
@@ -1,5 +1,5 @@
 version 1.1
-@totalColumns 11
+@totalColumns 14
 @separator TAB
 standort: notEmpty
 bundesland: any("BB", "BE", "BW", "BY", "HB", "HE", "HH", "MV", "NI", "NW", "RP", "SH", "SL", "SN", "ST", "TH")
@@ -12,3 +12,6 @@ loess_aenderung: regex("[0-9]+|(-?[0-9]+\.([0-9]+)(e-?[0-9]*)?)") or is("NA")
 einwohner: positiveInteger or is("NA")
 laborwechsel: any("ja", "nein", "NA")
 trend: any("Ansteigend", "Fallend", "Unverändert", "keine Daten vorhanden", "NA")
+normalisierung: any("ja", "nein", "NA")
+typ: any("Influenza-A", "Influenza-B", "Influenza-Gesamt", "SARS-CoV-2")
+unter_bg: any("ja", "nein", "NA")

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Nordufer 20
 <br>
 
 **Zitieren**  
-Fachgebiet 32, Robert Koch-Institut (2024): Abwassersurveillance AMELAG, Berlin: Zenodo. [DOI: 10.5281/zenodo.13939299](https://doi.org/10.5281/zenodo.13939299)
+Fachgebiet 32, Robert Koch-Institut (2024): Abwassersurveillance AMELAG, Berlin: Zenodo. [DOI: 10.5281/zenodo.12635858](https://doi.org/10.5281/zenodo.12635858)
 
 
 ---
@@ -20,8 +20,8 @@ Fachgebiet 32, Robert Koch-Institut (2024): Abwassersurveillance AMELAG, Berlin:
 
 ## Informationen zum Datensatz und Entstehungskontext
 
-Das Vorhaben „Abwassermonitoring für die epidemiologische Lagebewertung“ (AMELAG) läuft vom 22.11.2022 bis zum 31.12.2024. Behörden, Kläranlagen und Labore arbeiten zusammen, um Proben zu nehmen, zu analysieren und zu bewerten. Das Ziel dieses Vorhabens ist es, SARS-CoV-2-Nachweise aus dem Abwasser als zusätzlichen Indikator zur epidemiologischen Lagebewertung auf Länder- und Bundesebene zu etablieren. Ebenso ist es das Ziel, Strukturen und Prozesse für ein bundesweites Netzwerk für die Abwassersurveillance weiter auszubauen, Konzepte für eine Verstetigung zu erstellen und die Möglichkeiten für ein Monitoring von weiteren Krankheitserregern im Abwasser zu erforschen. 
-Abwassersurveillance ist eine Technik, um Erreger im Abwasser nachzuweisen, um Gesundheitsschutzmaßnahmen besser steuern zu können. Abwasserdaten erlauben keine genaue Einschätzung von Krankheitsschwere oder der Belastung des Gesundheitssystems. Bei der epidemiologischen Bewertung sollten die Daten mit anderen Indikatoren, z.B. aus der syndromischen Surveillance, kombiniert werden. 
+Das Vorhaben „Abwassermonitoring für die epidemiologische Lagebewertung“ (AMELAG) läuft vom 22.11.2022 bis zum 31.12.2024. Behörden, Kläranlagen und Labore arbeiten zusammen, um Proben zu nehmen, zu analysieren und zu bewerten. Das Ziel dieses Vorhabens ist es, SARS-CoV-2-Nachweise aus dem Abwasser als zusätzlichen Indikator zur epidemiologischen Lagebewertung auf Länder- und Bundesebene zu etablieren. Ebenso ist es das Ziel, Strukturen und Prozesse für ein bundesweites Netzwerk für die Abwassersurveillance weiter auszubauen, Konzepte für eine Verstetigung zu erstellen und die Möglichkeiten für ein Monitoring von weiteren Krankheitserregern im Abwasser zu erforschen. Aktuell werden Abwasserproben von ausgewählten Kläranlagen auf SARS-CoV-2 und Influenzaviren untersucht. 
+Bei der Abwassersurveillance werden Erreger im Abwasser gemessen um Gesundheitsschutzmaßnahmen besser steuern zu können. Abwassersurveillance kann einen Beitrag für eine Reihe von [Anwendungsfällen](https://www.rki.de/DE/Content/Infekt/EpidBull/Archiv/2024/Ausgaben/34_24.pdf?__blob=publicationFile) liefern. Abwasserdaten unterliegen speziellen Limitationen, beispielsweise erlauben sie keine genaue Einschätzung von Krankheitsschwere oder Belastung des Gesundheitssystems. Bei der epidemiologischen Bewertung sollten die Daten mit anderen Indikatoren, z.B. aus der syndromischen Surveillance, kombiniert werden. 
 
 ### Administrative und organisatorische Angaben
 
@@ -36,15 +36,15 @@ Weitere Kläranlagen und Labore sind Teil der folgenden Forschungsprojekte:
 -	Entwicklung einer landesweiten Abwassersurveillance in Thüringen mittels Mobilitätsdaten und künstlicher Intelligenz (Forschungskonsortium der Universität Weimar, Universität Jena, Universität Hamburg, Hochschule Hamm-Lippstadt, SMA Development GmbH, KOWUG Kommunale Wasser- und Umwelttechnik GmbH, Analytik Jena GmbH) 
 -	Etablierung einer Multiplex-PCR aus Abwasser und für Detektion und Charakterisierung von RSV im Rahmen des SARS-CoV-2-Abwasser-Monitoring (AMELAG) (Universität Bonn und Düsseldorf).  
 
-Die Firma [ENDA](https://enda.eu/) wurde mit der Datenhaltung beauftragt. Die erhobenen Daten werden dort in einer Datenbank (PiA-Monitor ) gespeichert und weiterverarbeitet. 
+Die Firma [ENDA](https://enda.eu/) wurde mit der Datenhaltung beauftragt. Die erhobenen Daten werden dort in einer Datenbank (PiA-Monitor) gespeichert und weiterverarbeitet. 
 
 Die Verarbeitung, Aufbereitung und Veröffentlichung der Daten erfolgen durch das Fachgebiet MF 4 | Fach- und Forschungsdatenmanagement. Fragen zum Datenmanagement und zur Publikationsinfrastruktur können an das Open Data-Team des Fachgebiets MF4 unter [OpenData@rki.de](mailto:OpenData@rki.de) gerichtet werden.
 
 #### Datenerhebung
 
-In AMELAG wurden aufbauend auf die im Rahmen des [ESI-CorA-Projekts](https://doi.org/10.5281/zenodo.10781652) erstellten Handreichungen zur Probennahme und Laboranalytik [technische Leitfäden](http://www.rki.de/abwassersurveillance) entwickelt. Die Rohdaten der im ESI-CorA-Projekt analysierten Proben sind in AMELAG nachgenutzt und in den ausgewerteten Daten enthalten.
+In AMELAG wurden aufbauend auf die im Rahmen des [ESI-CorA-Projekts](https://doi.org/10.5281/zenodo.10781652) erstellten Handreichungen zur Probennahme und Laboranalytik [technische Leitfäden](http://www.rki.de/abwassersurveillance) entwickelt. Die SARS-CoV-2-Rohdaten der im ESI-CorA-Projekt analysierten Abwasserproben wurden in AMELAG nachgenutzt und sind in den ausgewerteten Daten enthalten.
 An jeder beteiligten Kläranlage werden in aller Regel zwei Mal pro Woche Rohabwasserproben entnommen und zusammen mit den Begleitparametern (z.B. Volumenstrom, pH-Wert, Temperatur), die für die Normalisierung und Qualitätssicherung nötig sind, erhoben. Die Rohabwasserproben sollen, sofern möglich, nach dem Sandfang der Kläranlage entnommen werden. Es wird eine 24-Stunden-Mischprobe entnommen, welche mit einem automatischen Probennehmer durchgeführt wird. Die 24-Stunden-Probennahmen erfolgen in der Regel jeweils montags auf dienstags und mittwochs auf donnerstags. Im Regelfall wird ein Liter der Probe in Probenflaschen abgefüllt und an das Analyselabor versendet.
-Im Labor erfolgt die Aufkonzentrierung, Extraktion der viralen Nukleinsäure und Quantifizierung der viralen Gensequenzen durch digitale PCR (dPCR) oder quantitative real time PCR (qRT-PCR). Mindestens zwei repräsentative SARS-CoV-2 Genfragmente (Vorzugsweise N1, N2, E, ORF oder RdRp) werden bestimmt. 
+Im Labor erfolgt die Aufkonzentrierung, Extraktion der viralen Nukleinsäure und Quantifizierung der viralen Gensequenzen durch digitale PCR (dPCR) oder quantitative real time PCR (qRT-PCR). Bei SARS-CoV-2 werden mindestens zwei Genfragmente (Vorzugsweise N1, N2, E, ORF oder RdRp) bestimmt und bei den Influenzaviren ein Genfragment (M1 für Influenza-A-Virus und M1, NS1, NS2 oder HA für Influenza-B-Virus).
 
 > Robert Koch-Institut, Fachgebiet 32 (2024): "ESI-CorA: SARS-CoV-2-Abwassersurveillance" [Data set]. Zenodo. DOI: [10.5281/zenodo.10781653](https://doi.org/10.5281/zenodo.10781652)
 
@@ -52,16 +52,16 @@ Im Labor erfolgt die Aufkonzentrierung, Extraktion der viralen Nukleinsäure und
 
 ![Datenfluss AMELAG](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/.github/pictures/AMELAG_Datenfluss.png?raw=true "Datenfluss AMELAG")
     
-Beim UBA laufen die Metadaten zu den Kläranlagenstandorten und den Laboren sowie die regelmäßig erhobenen Monitoringdaten zentral in einer Webanwendung, dem PiA-Monitor (Pathogene im Abwasser), zusammen, werden dort gespeichert und weiterverarbeitet. Die regelmäßig zu erfassenden Monitoringdaten der Kläranlagen und die Analysedaten der Labore werden zusammengeführt und von den datenliefernden Stellen über die Web-Anwendung der Datenbank importiert. Das Umweltbundesamt, das RKI und die Bundesländer können auf die Daten im Rahmen ihrer jeweiligen Rechte zugreifen.
+Beim UBA laufen die Metadaten zu den Kläranlagen und den Laboren sowie die regelmäßig erhobenen Monitoringdaten zentral in einer Webanwendung, dem PiA-Monitor (Pathogene im Abwasser), zusammen, werden dort gespeichert und weiterverarbeitet. Die regelmäßig zu erfassenden Monitoringdaten der Kläranlagen und die Analysedaten der Labore werden zusammengeführt und von den datenliefernden Stellen über die Web-Anwendung der Datenbank importiert. Das UBA, das RKI und die Landesbehörden können auf die Daten im Rahmen ihrer jeweiligen Rechte zugreifen.
 
 ### Plausibilitätsprüfung und Weiterverarbeitung der Daten
 
-Mit dem Datenimport werden die Daten auf Plausibilität geprüft. Dabei werden die Formate, Vollständigkeit der Angaben (Pflichtfeldangaben), Wertebereiche der Monitoringdaten, Plausibilität der Datumsangaben und die Übereinstimmung mit hinterlegten Metadaten geprüft. Nur Datensätze, welche die Qualitätsprüfung erfolgreich durchlaufen, werden auch in die Datenbank importiert. Es wird der geometrische Mittelwert der Viruslast (Genkopien/Liter) aus den zwei oder mehr gemessenen Zielgenen ermittelt.
+Mit dem Datenimport werden die Daten auf Plausibilität geprüft. Dabei werden die Formate, Vollständigkeit der Angaben (Pflichtfeldangaben), Wertebereiche der Monitoringdaten, Plausibilität der Datumsangaben und die Übereinstimmung mit hinterlegten Metadaten geprüft. Nur Datensätze, welche die Qualitätsprüfung erfolgreich durchlaufen, werden auch in die Datenbank importiert. Für SARS-CoV-2 wird der geometrische Mittelwert der Viruslast (Genkopien/Liter) aus den zwei oder mehr gemessenen Zielgenen ermittelt.
 
 #### Normalisierungsverfahren
 
 Eine variierende Abwasserzusammensetzung, z. B. aufgrund von unregelmäßigen industriellen Einflüssen oder Starkregenereignissen, kann zu veränderten Konzentrationen von SARS-CoV-2 führen. Um diese externen Einflüsse zu berücksichtigen, kann die gemessene Viruslast normalisiert werden. 
-In AMELAG wird nach Durchfluss normalisiert. Dabei ist der Trockenwetterzufluss der Kläranlage die Referenz. Folgende Formel wurde hierbei verwendet: 
+In AMELAG wird die SARS-CoV-2-Last auf den Durchfluss der Kläranlage normalisiert. Dabei ist der Trockenwetterzufluss der Kläranlage die Referenz. Folgende Formel wurde hierbei verwendet: 
 
 $$ Gene_{normalisiert} = {Q_{KA\_aktuell}}/{Q_{KA\_median}} \cdot Gene_{gemittelt} $$
 
@@ -70,12 +70,15 @@ wo:
 - $Q_{KA\_aktuell}$ : Volumenstrom der Kläranlage im Probenahmezeitraum und  
 - $Q_{KA\_median}$ : Median des Volumenstrom der Kläranlage  
 
-Die Normalisierung erfolgt automatisiert mit dem Datenimport. 
+Die Normalisierung erfolgt automatisiert mit dem Datenimport. Die gemessenen Viruslasten von Influenzaviren werden derzeit nicht normalisiert, da sich für die Influenzavirusdaten keine verbesserte Datenqualität durch die Normalisierung feststellen lässt. 
 
 ### Datenauswertung
 
-Die Auswertung der Daten erfolgt am RKI über R-Skripte. Die Skripte sind in den [Kontextmaterialien](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Kontextmaterialien) enthalten. Eine genaue Beschreibung der Methodikist in den [technische Leitfäden](http://www.rki.de/abwassersurveillance) hinterlget. Die Ergebnisse werden in einem wöchentlichen Bericht des RKI [Wochenbericht](https://www.rki.de/DE/Content/Institut/OrgEinheiten/Abt3/FG32/Abwassersurveillance/Bericht_Abwassersurveillance.html) veröffentlicht. 
-Für jeden Standort werden die Messwerte in Genkopien pro Liter (Genkopien/L) angegeben. Zusätzlich werden die Messwerte der logarithmierten normalisierten Genkopien mittels einer lokal gewichteten Regression (LOESS) geglättet und zugehörige Konfidenzintervalle berechnet. Der Trend für einen Standort ergibt sich aus der Veränderung des von der LOESS-Methode geschätzten Werts an einem Mittwoch einer Woche gegenüber dem für den vorherigen Mittwoch vorhergesagten Wert, wobei die Werte vorher zurück auf die Originalskala transformiert wurden. 
+Die Auswertung der Daten erfolgt am RKI über R-Skripte. Die Skripte sind in den [Kontextmaterialien](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Kontextmaterialien) enthalten. Eine genaue Beschreibung der Methodikist in den [technischen Leitfäden](http://www.rki.de/abwassersurveillance) hinterlget. Die Ergebnisse werden wöchentlich im AMELAG [Wochenbericht](https://edoc.rki.de/handle/176904/11665) auf der RKI-Webseite veröffentlicht. 
+
+Für jeden Standort werden die Messwerte für SARS-CoV-2 (normalisiert) und Influenza A und B-Virus (nicht normalisiert) in Genkopien pro Liter (Genkopien/L) angegeben. Zusätzlich werden die Messwerte der logarithmierten und ggf. normalisierten Genkopien mittels einer lokal gewichteten Regression (LOESS) geglättet und zugehörige Konfidenzintervalle berechnet. 
+
+Für SARS-CoV-2 wird ein Trend berechnet. Der Trend für eine Kläranlage ergibt sich aus der Veränderung des von der LOESS-Methode geschätzten Werts an einem Mittwoch einer Woche gegenüber dem für den vorherigen Mittwoch vorhergesagten Wert, wobei die Werte vorher zurück auf die Originalskala transformiert wurden. 
 - `fallend`: die geglättete Viruslast ist um mehr als 15% zur Vorwoche gesunken 
 - `ansteigend`: die geglättete Viruslast ist um mehr als 15% zur Vorwoche gestiegen
 - `gleichbleibend`: die geglättete Viruslast hat sich nicht mehr als 15% zur Vorwoche verändert 
@@ -84,26 +87,30 @@ Für jeden Standort werden die Messwerte in Genkopien pro Liter (Genkopien/L) an
 
 #### Aggregation der Standortwerte
 
-Es werden die einzelnen Zeitreihen der Standorte aggregiert, um einen bundesweiten Verlauf der SARS-CoV-2-Viruslast im Abwasser abzubilden. Dafür werden in jeder Woche, in der für mindestens 10 Standorte Messwerte vorliegen, der Mittelwert über die über eine Woche gemittelten logarithmierten Messwerte der einzelnen Standorte berechnet. Dabei wird nach den angeschlossenen Einwohnern der Kläranlage gewichtet.
+Es werden die einzelnen Zeitreihen der Standorte aggregiert, um einen bundesweiten Verlauf der SARS-CoV-2 bzw. Influenzaviren-Viruslast im Abwasser abzubilden. Dafür werden in jeder Woche, in der für mindestens 10 Standorte Messwerte vorliegen, der Mittelwert über die über eine Woche gemittelten logarithmierten Messwerte der einzelnen Standorte berechnet. Dabei wird nach den angeschlossenen Einwohnern der Kläranlage gewichtet. Für Influenzaviren erfolgt derzeit keine Gewichtung nach Einwohnern. 
 
 ### Hinweise zur Datenauswertung
 
 Bei der Datenbewertung sind einige Besonderheiten zu beachten:
 
-* Es wurden an den unterschiedlichen Standorten verschiedene Zielgene gemessen (eine Kombination aus vorzugsweise N1, N2, E, ORF oder RdRp).
+* Es wurden an den unterschiedlichen Kläranlagen und für die unterschiedlichen Viren verschiedene Zielgene gemessen 
+    * SARS-CoV-2: eine Kombination aus vorzugsweise N1, N2, E, ORF oder RdRp
+    * Influenza A-Virus: M1
+    * InfluenzaB-Virus: M1, NS1, NS2, HA
 * Der Standort Hamburg ist mit zwei Zuläufen vertreten: “Hamburg Nord” und “Hamburg Süd”.
-* Im Sommer 2023 lag die Viruslast an einzelnen Tagen / Standorten teilweise unter der Bestimmungsgrenze (BG). In diesen Fällen wurde $0.5 \cdot BG$ als Wert eingetragen. Lag in einigen, seltenen Fällen keine Bestimmungsgrenze vor, wurde 4000 Genkopien/L als BG genommen.
+* Bei Werten unterhalb der Bestimmungsgrenze (BG) wird mit der Hälfte der Bestimmungsgrenze als Wert gerechnet (0,5 * BG).
 
 #### Limitationen 
 
 Abwasserdaten erlauben keinen Rückschluss auf die Krankheitsschwere oder die Belastung des Gesundheitssystems. Aus Abwasserdaten kann nach aktuellem Stand nicht präzise auf Inzidenz/Prävalenz oder die Untererfassung (die sog. „Dunkelziffer”) geschlossen werden. Für die epidemiologische Lagebewertung sollten die Daten immer in Zusammenschau mit anderen Indikatoren, z.B. aus der syndromischen Surveillance, betrachtet werden.
 Absolute Viruslasten können insbesondere über längere Zeiträume nicht direkt im Hinblick auf die Anzahl an Infizierten verglichen werden, da sich die ausgeschiedene Virusmenge pro infizierter Person beispielsweise zwischen verschiedenen Virusvarianten unterscheiden kann.
 Die ermittelten Werte werden durch eine Vielzahl von Faktoren (z.B. Veränderungen der Abwasserzuleitung, Starkregenereignisse oder touristische Ereignisse) beeinflusst, was durch die Normalisierung nur teilweise ausgeglichen werden kann.
-Der Zeitverzug von der Probenahme bis zur Übermittlung und weitere Veröffentlichung vom RKI kann bis zu zwei Wochen dauern. 
+
+Von der Probenahme bis zur Datenübermittlung und Veröffentlichung vom RKI kann es zu einem Zeitverzug von bis zu zwei Wochen kommen.
 
 ## Inhalt und Aufbau des Datensatzes  
 
-Im AMELAG-Datensatz werden Daten und Kontextmaterialien zu SARS-CoV-2-Nachweisen im Abwasser bereitgestellt. Die im Projekt erhobenen Daten, liegen für [einzelne Standorte](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Normalisierten-Daten-zur-SARS-CoV-2-Viruslast) und als [aggregierte Zeitreihe](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Zeitreihe-der-SARS-CoV-2-Viruslast) vor.
+Im AMELAG-Datensatz werden Daten und Kontextmaterialien zu SARS-CoV-2-Nachweisen im Abwasser bereitgestellt. Die im Projekt erhobenen Daten liegen für [einzelne Standorte](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Normalisierten-Daten-zur-SARS-CoV-2-Viruslast) und als [aggregierte Zeitreihe](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Zeitreihe-der-SARS-CoV-2-Viruslast) vor.
 
 Im Datensatz zusätzlich enthalten sind:
 - Lizenz-Datei mit der Nutzungslizenz des Datensatzes in Deutsch und Englisch
@@ -111,9 +118,9 @@ Im Datensatz zusätzlich enthalten sind:
 - Metadaten zur automatisierten Weiterverarbeitung
 - Kontexmaterialien zur Datenanalyse
 
-### Normalisierten Daten zur SARS-CoV-2-Viruslast  
+### Daten für die einzelnen Standorte
 
-In der Datei [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv) sind die normalisierten Daten zur SARS-CoV-2-Viruslast für die einzelnen Standorte angegeben. 
+In der Datei [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv) sind die normalisierten Daten zur SARS-CoV-2-Viruslast und die nicht normalisierten Daten zur Influenza A- und B-Viruslast für die einzelnen Standorte angegeben. 
 
 > [amelag_einzelstandorte.tsv](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv)
 
@@ -134,10 +141,13 @@ Die Datei [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut
 | einwohner | Natürliche Zahl | `≥0` oder `NA` | Einwohner, die an das Klärwerk des Standortes angeschlossen sind. |
 | trend | Text | `Ansteigend`, `Fallend`, `Unverändert`, `keine Daten vorhanden`, `NA` | Kategorisierte Veränderung des geglätteten LOESS-Wertes von einem Mittwoch zum Mittwoch der Vorwoche (siehe [Datenauswertung](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Datenauswertung))|
 | laborwechsel | Text | `ja`, `nein` oder `NA` | Laborwechsel bzw. Änderungen in den Labormethoden. |
+| normalisierung | Text | `ja`, `nein` oder `NA` | Normalisierung nach Durchfluss. |
+| typ | Text | `SARS-CoV-2`, `Influenza A`, `Influenza B` oder `Influenza A+B` | Virustyp. |
+| unter_bg | Text | `ja`, `nein` oder `NA` | Mindestens die Hälfte der gemessenen Gene liegen unterhalb der Bestimmungsgrenze. |
 
-### Zeitreihe der SARS-CoV-2-Viruslast
+### Daten über alle Standorte aggregiert
 
-In  der Datei [`amelag_aggregierte_kurve.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv)  ist die Zeitreihe der SARS-CoV-2-Viruslast auf aggregierter bzw. bundesweiter Ebene enthalten.
+In der Datei [`amelag_aggregierte_kurve.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv) ist die Zeitreihe der SARS-CoV-2-, Influenza A- und Influenza B-Viruslast auf aggregierter bzw. bundesweiter Ebene enthalten.
 
 > [amelag_aggregierte_kurve.tsv](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv)
 
@@ -154,32 +164,14 @@ Die Datei [`amelag_aggregierte_kurve.tsv`](https://github.com/robert-koch-instit
 | loess_vorhersage | Gleitkommazahl | `≥0` oder `NA` | Die mittels einer LOESS-Regression vorhergesagten Viruslasten, zurücktransformiert auf die Originalskala.|
 | loess_obere_schranke | Gleitkommazahl | `≥0` | Obere Grenze des punktweisen 95%-Konfidenzintervalls des LOESS-Vorhersagewerts. |
 | loess_untere_schranke | Gleitkommazahl | `≥0` | Untere Grenze des punktweisen 95%-Konfidenzintervalls des LOESS-Vorhersagewerts. |
+| normalisierung | Text | `ja`, `nein` oder `NA` | Unterliegenden Einzelzeitreihen nach Durchfluss normalisiert. |
+| typ | Text | `SARS-CoV-2`, `Influenza A`, `Influenza B` oder `Influenza A+B` | Virustyp. |
 
 ### Kontextmaterialien
 
-Zur Reproduktion der Ergebnisse des [AMELAG Wochenberichts](https://www.rki.de/DE/Content/Institut/OrgEinheiten/Abt3/FG32/Abwassersurveillance/Bericht_Abwassersurveillance.html?__blob=publicationFile) werden die zur Erstellung der Analyse verwendeten R-Skripte bereitgestellt. Die Skripte befinden sich im Ordner "[Kontextmatrialien](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien)" des Datensatzes. Die Analysen wurden mit R 4.3.0 (64 bit, Windows) durchgeführt. Sie können die Projektumgebung mit dem Paket [renv](https://rstudio.github.io/renv/articles/renv) nachbilden.
+Zur Reproduktion der Ergebnisse des [AMELAG Wochenberichts](https://edoc.rki.de/handle/176904/11665) werden die zur Erstellung der Analyse verwendeten R-Skripte bereitgestellt. Die Skripte befinden sich im Ordner "[Kontextmatrialien](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien)" des Datensatzes.
 
 > [Kontextmatrialien](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien)
-
-#### Struktur der Skripte
-
-Das R-Skript [`main.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/main.R) erzeugt alle Grafiken, die im Wochenbericht angezeigt werden. Setzen Sie `show_log_data = FALSE` am Anfang von `main.R`, um Plots auf der Originalskala (statt auf der Logskala) zu erzeugen. Die Datei `main.R` ruft alle R-Skripte auf, die im Unterordner [`Scripts`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien/Scipts) gespeichert sind und speichert alle Ergebnisse im Ordner `Results` und seinen Unterordnern. Die folgenden R-Skripte sind im Ordner `Scripts` verfügbar: 
-
-* [`functions_packages.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/functions_packages.R): Installiert (falls erforderlich) und lädt notwendige Pakete, definiert selbst geschriebene Funktionen und setzt Parameter und Variablen, die in anderen Skripten verwendet werden.
-
-* [`loess_calculation.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/loess_calculation.R): Löscht LOESS-Berechnungen, entsprechende Konfidenzintervalle und berechnete Trends aus `amelag_einzelstandorte.tsv` im Ordner `Data` und zeigt, wie man diese Größen berechnet. 
-
-* [`aggregation_calculation.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/aggregation_calculation.R): Ausgehend von den Daten `amelag_einzelstandorte.tsv` im Ordner `Data` zeigt dieses Skript, wie man die Daten aggregiert und die LOESS-Kurve und ihre jeweiligen Konfidenzintervalle für die aggregierten Daten berechnet. Im Wesentlichen zeigt dieses Skript, wie man aus `amelag_einzelstandorte.tsv` den Datensatz `amelag_aggregierte_kurve.tsv` erhält.
-
-* [`plot_single_places.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/plot_single_places.R): Erzeugt eine Zeitreihengrafik mit einer LOESS-Kurve für jeden Standort, der genügend Daten geliefert hat. Speichert auch beobachtete und mittels LOESS geschätzte Abwasserdaten für jeden Standort, der genügend Daten geliefert hat. Für Standorte ohne ausreichende Daten werden keine LOESS-Schätzungen berechnet und gespeichert.
-
-* [`plot_aggregated_curve.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/plot_aggregated_curve.R): Erzeugt eine Zeitreihendarstellung mit einer LOESS-Kurve für die über alle Standorte aggregierten Daten.  
-
-* [`plot_heatmap.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/plot_heatmap.R): Erzeugt eine Heatmap, die Trends für alle Standorte zeigt, die genügend Daten geliefert haben.  
-
-#### Ergebnisse
-Nach dem Ausführen von `main.R` enthält der Ordner `Results` die Heatmap und die aggregierte Kurve in seinem Hauptverzeichnis und die Kurven und Daten für die einzelnen Standorte in seinem Unterordner `Single_Sites`.
-
 
 ### Metadaten  
 
@@ -234,14 +226,15 @@ Nordufer 20
 <br>
 
 **Cite**  
-Fachgebiet 32, Robert Koch-Institut (2024): Abwassersurveillance AMELAG, Berlin: Zenodo. [DOI: 10.5281/zenodo.13939299](https://doi.org/10.5281/zenodo.13939299)
+Fachgebiet 32, Robert Koch-Institut (2024): Abwassersurveillance AMELAG, Berlin: Zenodo. [DOI: 10.5281/zenodo.12635858](https://doi.org/10.5281/zenodo.12635858)
 
 ---
 
 ## Information on the dataset and context of origin
 
-The project "Wastewater monitoring for epidemiological situation assessment" (AMELAG) runs from 22.11.2022 to 31.12.2024. Local authorities, wastewater treatment plants (WWTP) and laboratories are working together to take, analyze and evaluate wastewater samples. The project aims at establishing SARS-CoV-2 detection in wastewater as an additional indicator for the epidemiological situation assessment at state and federal level. Further aims of the project include further development of structures and processes for a nationwide network for wastewater surveillance, to develop concepts for continuity and to research the possibilities for monitoring other pathogens in wastewater. 
-Wastewater surveillance is a technique for detecting pathogens in wastewater to better control health protection measures. Wastewater data do not allow for an accurate assessment of disease severity or the burden on the healthcare system. In epidemiological assessments, the data should be combined with other indicators, e.g. from syndromic surveillance. 
+In AMELAG (“Abwassermonitoring für die epidemiologische Lagebewertung”, German for wastewater monitoring for epidemiological situation assessment), running from 22.11.2022 to 31.12.2024, local authorities, wastewater treatment plants (WWTP) and laboratories are working together to take, analyze and evaluate wastewater samples. The project aims at testing wastewater samples for selected pathogens and to establish it as an additional indicator for the epidemiological situation assessment at state and federal level. Further aims of the project include further development of structures and processes for a nationwide wastewater surveillance network, to develop concepts for continuity and to research the possibilities for monitoring other pathogens in wastewater. Currently, wastewater samples from selected treatment plants are being tested for SARS-CoV-2 and influenza viruses. 
+
+Wastewater surveillance is a technique for detecting pathogens in wastewater to better control health protection measures. Wastewater surveillance has a range of [applications](https://www.rki.de/DE/Content/Infekt/EpidBull/Archiv/2024/Ausgaben/34_24.pdf?__blob=publicationFile). Wastewater data, however, underlie several limiations. For example, they do not allow for an accurate assessment of disease severity or the burden on the healthcare system. In epidemiological assessments, the data should be combined with other indicators, e.g. from syndromic surveillance. 
 
 ### Administrative and organizational information
 
@@ -262,9 +255,9 @@ The data are processed, edited and published by the Department MF 4 | Subject an
 
 #### Data collection
 
-In AMELAG, [technical guidelines](http://www.rki.de/abwassersurveillance) were developed based on the handouts for sampling and laboratory analysis created as part of the [ESI-CorA project](https://doi.org/10.5281/zenodo.10781652). The raw data of the samples analyzed in the ESI-CorA project are reused in AMELAG and included in the evaluated data.
+In AMELAG, [technical guidelines](http://www.rki.de/abwassersurveillance) were developed based on the handouts for sampling and laboratory analysis created as part of the [ESI-CorA project](https://doi.org/10.5281/zenodo.10781652). The raw data of the SARS-CoV-2 samples analyzed in the ESI-CorA project are reused in AMELAG and included in the evaluated data.
 Raw wastewater samples are generally collected twice a week at each participating WWTP, along with essential parameters such as volume flow, pH value, and temperature. These parameters are necessary for normalization and quality assurance. Where possible, the raw sewage samples should be taken after the grit chamber of the WWTP. A 24-hour composite sample is collected using an automatic sampler. The 24-hour samples are usually taken from Mondays to Tuesdays, and from Wednesdays to Thursdays. As a rule, one liter of the sample is filled into sample bottles and sent to the analysis laboratory.
-In the laboratory, the viral nucleic acid is concentrated, extracted and the viral gene sequences are quantified by digital PCR (dPCR) or quantitative real-time PCR (qRT-PCR). At least two representative SARS-CoV-2 gene fragments (preferably N1, N2, E, ORF or RdRp) are determined. 
+In the laboratory, the viral nucleic acid is concentrated, extracted and the viral gene sequences are quantified by digital PCR (dPCR) or quantitative real-time PCR (qRT-PCR). For SARS-CoV-2, at least two representative gene fragments (preferably N1, N2, E, ORF or RdRp) are determined, for the Influenza virus only one gene fragment (M1 for Influenza A Virus and M1, NS1, NS2 or HA for Influenza B Virus). 
 
 > Robert Koch Institute, Department 32 (2024): "ESI-CorA: SARS-CoV-2 wastewater surveillance" [Dataset]. Zenodo. DOI: [10.5281/zenodo.10781653](https://doi.org/10.5281/zenodo.10781652)
 
@@ -276,12 +269,12 @@ At the UBA, metadata on the WWTPs and the laboratories as well as the regularly 
 
 ### Plausibility check and further processing of the data
 
-A plausibility check is run on the data as they are imported. The formats, completeness of the information (mandatory fields), value ranges of the monitoring data, plausibility of the dates and compliance with stored metadata are checked. Only data records that successfully pass the quality check are imported into the database. The geometric mean of the viral load (gene copies/L) is then determined from the two or more measured target genes.
+A plausibility check is run on the data as they are imported. The formats, completeness of the information (mandatory fields), value ranges of the monitoring data, plausibility of the dates and compliance with stored metadata are checked. Only data records that successfully pass the quality check are imported into the database. For SARS-CoV-2, the geometric mean of the viral load (gene copies/L) is then determined from the two or more measured target genes.
 
 #### Normalization procedure
 
 A varying wastewater composition, e.g. due to irregular industrial influences or heavy rainfall events, can lead to changing concentrations of SARS-CoV-2. To take these external influences into account, the measured viral load can be normalized. 
-In AMELAG, normalization is performed according to flow rate. The dry weather inflow of the WWTP is the reference. The following formula was used: 
+In AMELAG, normalization of the SARS-CoV-2 data is performed according to flow rate. The dry weather inflow of the WWTP is the reference. The following formula was used: 
 
 $$ Gene_{normalized} = {Q_{KA\_current}}/{Q_{KA\_median}} \cdot Gene_{averaged} $$
 
@@ -290,33 +283,38 @@ where:
 - $Q_{KA\_aktuell}$ : Volume flow of the wastewater treatment plant in the sampling period and  
 - $Q_{KA\_median}$ : Median of the volume flow of the wastewater treatment plant  
 
-Normalization is automated with the data import. 
+Normalization is automated with the data import. The measured Influenza data are currently not normalized as the normalization does not show an imporved data quality for influenza viruses.  
 
 ### Data evaluation
 
 The data are evaluated at the RKI using R scripts. The scripts are contained in the [context materials](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Kontextmaterialien). A detailed description of the methodology is provided in the [technical guidelines](http://www.rki.de/abwassersurveillance). The results are published in the RKI´s [weekly report](https://www.rki.de/DE/Content/Institut/OrgEinheiten/Abt3/FG32/Abwassersurveillance/Bericht_Abwassersurveillance.html). 
-For each site, the measured values are reported in gene copies per liter (gene copies/L). In addition, the measured values of the logarithmized normalized gene copies are smoothed using a locally weighted regression (LOESS) and associated confidence intervals are calculated. The trend for a location results from the change in the value estimated by the LOESS method on a Wednesday of a week compared to the value predicted for the previous Wednesday, whereby the values were previously transformed back to the original scale. 
+For each WWTP, the measured values for SARS-CoV-2 (normalized) and Inlfuenza A and B viruses (not normalized) are reported in gene copies per liter (gene copies/L). In addition, the measured values of the logarithmized normalized gene copies are smoothed using a locally weighted regression (LOESS) and associated confidence intervals are calculated. 
+
+A trend is calculated for SARS-CoV-2. The trend for a WWTP results from the change in the value estimated by the LOESS method on a Wednesday of a week compared to the value predicted for the previous Wednesday, whereby the values were previously transformed back to the original scale. 
 - `falling`: The smoothed viral load has fallen by more than 15% compared to the previous week 
 - `increasing`: The smoothed viral load has increased by more than 15% compared to the previous week
 - `stable`: The smoothed viral load has not changed by more than 15% compared to the previous week 
 - `No data available`: No smoothed LOESS value is available for the Wednesday of this or the previous week
 - `NA`: Is entered for all days except Wednesday. 
 
-#### Aggregation of the location values
+#### Aggregation of the WWTP values
 
-The individual time series of the locations are aggregated in order to depict a nationwide course of the SARS-CoV-2 viral load in wastewater. For each week in which measured values are available for at least 10 sites, the average of the logarithmized measured values of the individual sites averaged over one week is calculated. This value is then weighted by the number of inhabitants connected to the WWTPs.
+The individual time series of the WWTP are aggregated in order to depict a nationwide course of the SARS-CoV-2 and Influenzavirus viral loads in wastewater. For each week in which measured values are available for at least 10 sites, the average of the logarithmized measured values of the individual sites averaged over one week is calculated. This value is then weighted by the number of inhabitants connected to the WWTPs. The influenza data are currently not weighted by the number of inhabitants.
 
 ### Notes on data evaluation
 
 Some things to take into account when evaluating the data:
 
-* Different target genes were measured at the different sites (a combination of preferably N1, N2, E, ORF or RdRp).
+* Different target genes were measured at the different sites
+    * SARS-CoV-2: a combination of preferably N1, N2, E, ORF oder RdRp
+    * Influenza A-Virus: M1
+    * Influenza B-Virus: M1, NS1, NS2, HA
 * The Hamburg site is represented by two inflows: "Hamburg North" and "Hamburg South".
-* In summer 2023, the viral load on individual days / locations was sometimes below the limit of quantification (BG). In these cases, $0.5 \cdot BG$ was entered as the value. If there was no limit of quantification in some rare cases, 4000 gene copies/L was taken as the BG.
+* For values below the limit of quantification (LOQ), half of the LOQ is used as the value (0.5 * LOQ).
 
 #### Limitations 
 
-Wastewater data do not allow conclusions to be drawn about disease severity or the burden on the healthcare system. As things stand at present, it is not possible to draw precise conclusions about incidence/prevalence or underreporting from wastewater data. When assessing a sitaution epidemiologically, the data should always be considered in conjunction with other indicators, such as those from syndromic surveillance.
+Wastewater data do not allow conclusions to be drawn about disease severity or the burden on the healthcare system. At present, it is not possible to draw precise conclusions about incidence/prevalence or underreporting from wastewater data. When assessing a sitaution epidemiologically, the data should always be considered in combination with other indicators, such as those from syndromic surveillance.
 Absolute viral loads cannot be compared directly to the number of infected persons, especially over longer periods of time, as, for example, the amount of virus excreted per infected person can differ between different virus variants.
 The values determined are influenced by a variety of factors (e.g. changes in the wastewater supply, heavy rainfall events, or tourist events), which can only be partially compensated for by normalization.
 The time delay from sampling to transmission and further publication by the RKI can take up to two weeks. 
@@ -331,9 +329,9 @@ The dataset also contains:
 - Metadata for automated further processing
 - Context materials for data analysis
 
-### Normalized data on SARS-CoV-2 viral load  
+### Data for individual WWTP 
 
-In the file [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv) contains the normalized SARS-CoV-2 viral load data for the individual sites. 
+The file [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv) contains the normalized SARS-CoV-2 and not normalized influenza virus viral load data for the individual sites. 
 
 > [amelag_einzelstandorte.tsv](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv)
 
@@ -350,14 +348,17 @@ The file [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut/
 | loess_vorhersage | Floating point number | `≥0` or ``NA``| The viral loads predicted using a LOESS regression (optimized using GCV criterion for the 10s logarithmized viral loads). |
 | loess_obere_schranke | Floating point number | `≥0` or ``NA`` | Upper bound of the pointwise 95% confidence interval of the LOESS predicted value. |
 | loess_untere_schranke | Floating point number | `≥0` or ``NA`` | Lower bound of the point-wise 95% confidence interval of the LOESS predicted value. |
-| loess_aenderung | Floating point number | `ℤ`` or ``NA`` | Change in the LOESS predicted value compared to the previous week, i.e. quotient of the current value and the previous week's value. |
+| loess_aenderung | Floating point number | `≥0` or ``NA`` | Change in the LOESS predicted value compared to the previous week, i.e. quotient of the current value and the previous week's value. |
 | einwohner | Natural number | `≥0` or `NA` | Inhabitants connected to the site's sewage treatment plant. |
 | trend | Text | `increasing`, `decreasing`, `unchanged`, `no data available`, `NA` | Categorized change in the smoothed LOESS value from a Wednesday to the Wednesday of the previous week (see [data evaluation](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main?tab=readme-ov-file#Datenauswertung))|
 | laborwechsel | Text | `ja`, `nein` or `NA` | Changes in laboratory or changes in the methods. |
+| normalisierung | Text | `ja`, `nein` or `NA` | Values are normalized by flowrate. |
+| typ | Text | `SARS-CoV-2`, `Influenza A`, `Influenza B` or `Influenza A+B` | Virus type. |
+| unter_bg | Text | `ja`, `nein` or `NA` | At least half of the measured Genes are under the limit of quantification. |
 
-### Time series of the SARS-CoV-2 viral load
+### Data aggregated across all WWTP 
 
-In the file [`amelag_aggregated_curve.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv)  contains the time series of the SARS-CoV-2 viral load on an aggregated or nationwide level.
+In the file [`amelag_aggregated_curve.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv)  contains the time series of the SARS-CoV-2 and influenza virus viral loads on an aggregated or nationwide level.
 
 > [amelag_aggregierte_kurve.tsv](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv)
 
@@ -374,32 +375,14 @@ The file [`amelag_aggregierte_kurve.tsv`](https://github.com/robert-koch-institu
 | loess_vorhersage | Floating point number | `≥0` or `NA` | The viral loads predicted using a LOESS regression, transformed back to the original scale.
 | loess_obere_schranke | Floating point number | `≥0` | Upper bound of the 95% confidence interval of the LOESS predicted value. |
 | loess_untere_schranke | Floating point number | `≥0` | Lower bound of the 95% confidence interval of the LOESS predicted value. |
+| normalisierung | Text | `ja`, `nein` or `NA` | Individual time series are normalized by flowrate. |
+| typ | Text | `SARS-CoV-2`, `Influenza A`, `Influenza B` or `Influenza A+B` | Virus type. |
 
 ### Context materials
 
-To reproduce the results of the [AMELAG weekly report](https://www.rki.de/DE/Content/Institut/OrgEinheiten/Abt3/FG32/Abwassersurveillance/Bericht_Abwassersurveillance.html?__blob=publicationFile), the R scripts used to create the analysis are provided. The scripts can be found in the "[Contextual materials](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien)" folder of the dataset. The analyses were conducted using R 4.3.0 (64 bit, Windows). You can recreate the project environment by using the package [renv](https://rstudio.github.io/renv/articles/renv).
+To reproduce the results of the [AMELAG weekly report](https://edoc.rki.de/handle/176904/11665), the R scripts used to create the analysis are provided. The scripts can be found in the "[Contextual materials](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien)" folder of the dataset.
 
 > [Context Matrials](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien)
-
-#### Structure of the scripts
-
-The R script [`main.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/main.R) generates all graphics that are displayed in the weekly report. Set `show_log_data = FALSE` at the beginning of `main.R` to generate plots on the original scale (instead of the log scale). The file `main.R` calls all R scripts stored in the subfolder [`Scripts`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/tree/main/Kontextmaterialien/Scipts) and stores all results in the folder `Results` and its subfolders. The following R scripts are available in the `Scripts` folder: 
-
-* [`functions_packages.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/functions_packages.R): Installs (if required) and loads necessary packages, defines self-written functions and sets parameters and variables used in other scripts.
-
-* [`loess_calculation.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/loess_calculation.R): Deletes LOESS calculations, corresponding confidence intervals and calculated trends from `amelag_einzelstandorte.tsv` in the `Data` folder and shows how to calculate these quantities. 
-
-* [`aggregation_calculation.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/aggregation_calculation.R): Starting with the data `amelag_einzelstandorte.tsv` in the `Data` folder, this script shows how to aggregate the data and calculate the LOESS curve and its respective confidence intervals for the aggregated data. Essentially, this script shows how to obtain the dataset `amelag_aggregated_curve.tsv` from `amelag_single_location.tsv`.
-
-* [`plot_single_places.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/plot_single_places.R): Generates a time series graph with a LOESS curve for each location that has provided sufficient data. Also stores observed and LOESS-estimated wastewater data for each location that provided sufficient data. LOESS estimates are not calculated and stored for sites without sufficient data.
-
-* [`plot_aggregated_curve.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/plot_aggregated_curve.R): Generates a time series plot with a LOESS curve for the data aggregated across all sites.  
-
-* [`plot_heatmap.R`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/Kontextmaterialien/Scripts/plot_heatmap.R): Creates a heatmap showing trends for all locations that have provided sufficient data.  
-
-#### Results
-After running `main.R` the folder `Results` contains the heatmap and the aggregated curve in its root directory and the curves and data for the individual sites in its subfolder `Single_Sites`.
-
 
 ### Metadata
 


### PR DESCRIPTION
Konkret werden in den beiden Datensatz-Files neue Spalten hinzugefügt.

An die Datei [`amelag_einzelstandorte.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_einzelstandorte.tsv) werden folgende Spalten hinzugefügt:

- **normalisierung**: Definiert, ob die Messwerte (nach Durchfluss) normalisiert wurden. Mögliche Werte sind `ja`, `nein`, `NA`
- **typ**: Definiert den gemessenen Virustyp. Mögliche Werte sind `Influenza-A`, `Influenza-B`, `Influenza-Gesamt`, `SARS-CoV-2`.
- **unter_bg**:  definiert ob ein Messwert unterhalb der Bestimmungsgrenze liegt. Mögliche Werte sind `ja`, `nein`, `NA`

An die Datei [`amelag_aggregierte_kurve.tsv`](https://github.com/robert-koch-institut/Abwassersurveillance_AMELAG/blob/main/amelag_aggregierte_kurve.tsv)  werden folgende Spalten hinzugefügt:

- **normalisierung**: Definiert, ob die Messwerte (nach Durchfluss) normalisiert wurden. Mögliche Werte sind `ja`, `nein`, `NA`
- **typ**: Definiert den gemessenen Virustyp. Mögliche Werte sind `Influenza-A`, `Influenza-B`, `Influenza-Gesamt`, `SARS-CoV-2`.

