### PR TITLE
Drop inconsistent SARS data from aggregation

### DIFF
--- a/Kontextmaterialien/Scripts/aggregation_calculation.R
+++ b/Kontextmaterialien/Scripts/aggregation_calculation.R
@@ -7,6 +7,18 @@ df <- read_tsv(here(read_data_here, "amelag_einzelstandorte.tsv"),
   filter(!(
     standort == "Dresden" &
       typ %in% c("Influenza A", "Influenza B" , "Influenza A+B")
+  )) %>% 
+  # remove inconsistent Sars data from a few sites from aggregation
+  filter(!(
+    standort %in% c(
+      "Bottrop",
+      "Dinslaken",
+      "Dortmund-Deusen",
+      "Dortmund-Scharnhorst",
+      "Duisburg",
+      "Emschermündung"
+    ) &
+      typ %in% "SARS-CoV-2"
   ))
 
 # generate weeks starting on Thursday


### PR DESCRIPTION
Daten von sechs Standorten, die in der Vorwoche erstmalig berücksichtigt wurden, werden diese Woche bei der Aggregation der SARS-CoV-2-Daten vorerst herausgenommen, um Unklarheiten bezüglich technischer Umstellungen in der Datenerhebung bei diesen Standorten zu klären.

Data from six sites that were included for the first time last week will be omitted from this week's aggregation of the SARS-CoV-2 data in order to clarify uncertainties regarding technical changes in data collection at these sites.