### PR TITLE
adapted adjustment procedure for aggregation of sites

### DIFF
--- a/Kontextmaterialien/Scripts/aggregation_calculation.R
+++ b/Kontextmaterialien/Scripts/aggregation_calculation.R
@@ -3,9 +3,9 @@ df <- read_tsv(here(read_data_here, "amelag_einzelstandorte.tsv"),
                show_col_types = FALSE) %>%
   # rename RSV A/B to avoid problems when saving data
   mutate(typ = ifelse(typ == "RSV A/B", "RSV AB", typ)) %>%
-  # remove unreliable / variable Influenza data from Dresden from aggregation
+  # remove unreliable / variable Influenza data from aggregation
   filter(!(
-    standort == "Dresden" &
+    standort %in% discard_places_for_aggregation_influenza &
       typ %in% c("Influenza A", "Influenza B" , "Influenza A+B")
   ))
 
@@ -51,12 +51,12 @@ df_agg <- df_agg %>%
   filter(!is.na(einwohner), !is.na(log_viruslast))
 
 df_agg <- df_agg %>%
-  # calculate unweighted means over the weeks as these unweighted means can be
-  # used to calculate differnces between site/lab combination from these means.
+  # calculate weighted means over the weeks as these weighted means can be
+  # used to calculate differences between site/lab combination from these means.
   # in this way, average differences in the viral loads that are site/lab
   # specific can be adjusted for.
   group_by(typ, th_week) %>%
-  mutate(mean_log_viruslast = mean(log_viruslast)) %>%
+  mutate(mean_log_viruslast = weighted.mean(log_viruslast, einwohner)) %>%
   ungroup() %>%
   # calculate differences from these means
   mutate(log_viruslast_dev = log_viruslast - mean_log_viruslast) %>%

--- a/Kontextmaterialien/Scripts/functions_packages.R
+++ b/Kontextmaterialien/Scripts/functions_packages.R
@@ -15,6 +15,11 @@ pacman::p_load(here,
 # accessed on 25/10/2023
 pop <- 84358845
 
+# remove unreliable / variable Influenza data from Dresden from aggregation
+discard_places_for_aggregation_influenza <- c(
+  "Dresden"
+)
+
 # define function that computes variance of a weighted mean
 var_weighted <- function(x = NULL, wt = NULL) {
   xm = weighted.mean(x, wt)

--- a/Kontextmaterialien/Scripts/plot_loq_plot.R
+++ b/Kontextmaterialien/Scripts/plot_loq_plot.R
@@ -1,5 +1,10 @@
 # read in data for single treatment plants
 plot_data <- read_tsv(here(read_data_here, "amelag_einzelstandorte.tsv")) %>%
+  # remove unreliable / variable Influenza data for aggregated plot
+  filter(!(
+    standort %in% discard_places_for_aggregation_influenza &
+      typ %in% c("Influenza A", "Influenza B" , "Influenza A+B")
+  )) %>% 
   # rename RSV A/B to avoid problems when saving data
   mutate(typ = ifelse(typ == "RSV A/B", "RSV AB", typ)) %>%
   filter(!is.na(!!sym(viruslast_untersucht))) %>%


### PR DESCRIPTION
The adjustment procedure, which accounts for average differences in site- or lab-specific viral loads, now uses weighted means instead of unweighted means to compute the average deviations of viral loads from these means. This change ensures greater consistency with the weighted mean across all sites, which is ultimately used to calculate a population-weighted national average. This is unlikely to substantially affect the overall trend of the aggregated viral loads, but it may lead to differences in their values.

Furthermore, unreliable influenza viral load measurements are now excluded not only from the computation of the national average (as before), but also from the plots summarizing the proportion of samples below the limit of quantification across all sites.