### PR TITLE
increase k in gam fit with growing sample size

### DIFF
--- a/Kontextmaterialien/Scripts/aggregation_calculation.R
+++ b/Kontextmaterialien/Scripts/aggregation_calculation.R
@@ -102,20 +102,33 @@ pred <- df_agg %>%
     # clean data
     d <- d_grp %>% filter(!is.na(log_viruslast), !is.na(obs))
     
-    # helper to fit GAM with a given k (basis dimension) and bs (spline basis)
-    fit_gam <- function(k, bs, method = "GCV.Cp") {
-      mgcv::gam(log_viruslast ~ s(obs, k = k, bs = bs),
-                method = method,
-                weights = sqrt(weights),     
-                data = d)
+    # Helper to fit GAM with a given k (basis dimension), maybe m and bs (spline basis) 
+    fit_gam <- function(k, bs, m = NULL) {
+      if (is.null(m)) {
+        mgcv::gam(
+          log_viruslast ~ s(obs, k = k, bs = bs),
+          data = d
+        )
+      } else {
+        mgcv::gam(
+          log_viruslast ~ s(obs, k = k, bs = bs, m = m),
+          data = d
+        )
+      }
     }
     
-    # Choose a default k: default is given to mgcv default
+    # Choose k for adaptive smooth: should grow with sample size
+    k_adapt <- max(40, floor(nrow(d) / 2.5))
+    
+    # Choose m for adaptive smooth: should grow with sample size
+    m_adapt <- max(1, floor(k_adapt / 10))
+    
+    # Choose a default k for non-adaptive smooth: default is given to mgcv default
     k_main <- -1
     
     # try to fit model with adaptive smooth
     fit <- tryCatch(
-      fit_gam(k_main, bs = "ad"),
+      fit_gam(k = k_adapt, m = m_adapt, bs = "ad"),
       warning = function(w) {
         message(
           "Warning in pathogen ",
@@ -125,7 +138,7 @@ pred <- df_agg %>%
         )
         # in case of error (mostly due to small observations) do not use adaptive smoothing
         tryCatch(
-          fit_gam(k_main, bs = "bs"),
+          fit_gam(k = k_main, bs = "bs"),
           error = function(e)
             NULL
         )

--- a/Kontextmaterialien/Scripts/aggregation_calculation.R
+++ b/Kontextmaterialien/Scripts/aggregation_calculation.R
@@ -107,11 +107,13 @@ pred <- df_agg %>%
       if (is.null(m)) {
         mgcv::gam(
           log_viruslast ~ s(obs, k = k, bs = bs),
+          weights = sqrt(weights),   
           data = d
         )
       } else {
         mgcv::gam(
           log_viruslast ~ s(obs, k = k, bs = bs, m = m),
+          weights = sqrt(weights),   
           data = d
         )
       }

--- a/Kontextmaterialien/Scripts/smoother_calculation.R
+++ b/Kontextmaterialien/Scripts/smoother_calculation.R
@@ -77,19 +77,35 @@ pred <- df %>%
     # clean data
     d <- d_grp %>% filter(!is.na(log_viruslast), !is.na(obs))
     
-    # helper to fit GAM with a given k (basis dimension) and bs (spline basis)
-    fit_gam <- function(k, bs, method = "GCV.Cp") {
-      mgcv::gam(log_viruslast ~ s(obs, k = k, bs = bs),
-                method = method,
-                data = d)
+    # Helper to fit GAM with a given k (basis dimension), maybe m and bs (spline basis) 
+    fit_gam <- function(k, bs, m = NULL, method = "GCV.Cp") {
+      if (is.null(m)) {
+        mgcv::gam(
+          log_viruslast ~ s(obs, k = k, bs = bs),
+          method = method,
+          data = d
+        )
+      } else {
+        mgcv::gam(
+          log_viruslast ~ s(obs, k = k, bs = bs, m = m),
+          method = method,
+          data = d
+        )
+      }
     }
     
-    # Choose a default k: default is given to mgcv default
+    # Choose k for adaptive smooth: should grow with sample size
+    k_adapt <- max(40, floor(nrow(d) / 2.5))
+    
+    # Choose m for adaptive smooth: should grow with sample size
+    m_adapt <- max(1, floor(k_adapt / 10))
+    
+    # Choose a default k for non-adaptive smooth: default is given to mgcv default
     k_main <- -1
     
     # try to fit model with adaptive smooth
     fit <- tryCatch(
-      fit_gam(k_main, bs = "ad"),
+      fit_gam(k_adapt, m = m_adapt, bs = "ad"),
       warning = function(w) {
         message(
           "Warning in group ",

--- a/Kontextmaterialien/Scripts/smoother_calculation.R
+++ b/Kontextmaterialien/Scripts/smoother_calculation.R
@@ -78,17 +78,15 @@ pred <- df %>%
     d <- d_grp %>% filter(!is.na(log_viruslast), !is.na(obs))
     
     # Helper to fit GAM with a given k (basis dimension), maybe m and bs (spline basis) 
-    fit_gam <- function(k, bs, m = NULL, method = "GCV.Cp") {
+    fit_gam <- function(k, bs, m = NULL) {
       if (is.null(m)) {
         mgcv::gam(
           log_viruslast ~ s(obs, k = k, bs = bs),
-          method = method,
           data = d
         )
       } else {
         mgcv::gam(
           log_viruslast ~ s(obs, k = k, bs = bs, m = m),
-          method = method,
           data = d
         )
       }


### PR DESCRIPTION
## Summary

This PR updates the GAM smoothing configuration used for wastewater viral-load trend estimation in the aggregation and site-level smoother scripts.

Instead of relying on the mgcv default basis dimension for adaptive smooths, the updated code now chooses an adaptive basis dimension based on the number of available observations. This should give the smoother enough flexibility to capture more variable time trends.

## Changed files

- `Kontextmaterialien/Scripts/aggregation_calculation.R`
- `Kontextmaterialien/Scripts/smoother_calculation.R`

## Main changes

- Introduces explicit adaptive GAM basis sizing:
  - `k_adapt <- max(40, floor(nrow(d) / 2.5))`
  - `m_adapt <- max(1, floor(k_adapt / 10))`
- Extends the GAM helper function to optionally pass `m` to `mgcv::s()`.
- Applies the updated adaptive smoothing logic to:
  - aggregated pathogen-level GAM predictions
  - site/pathogen/estimation-period/labor-level GAM predictions
- Keeps the existing fallback behavior: if the adaptive smooth raises a warning, the code retries with a non-adaptive spline.
